### PR TITLE
Add Xquik backend and fix trending skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Xquik backend** for Twitter/X KOL monitoring via `XQUIK_API_KEY`.
+- `--backend xquik` for `fetch-twitter.py` and `--twitter-backend xquik` for `run-pipeline.py`.
+
+### Fixed
+- `--skip trending` now skips GitHub Trending as documented.
+
 ## v3.17.1 — 2026-08-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -117,11 +117,12 @@ No need to copy the entire file — just include what you want to change.
 All environment variables are optional. The pipeline runs with whatever sources are available.
 
 ```bash
-# Twitter/X Backend (auto priority: getxapi > twitterapiio > official)
+# Twitter/X Backend (auto priority: getxapi > xquik > twitterapiio > official)
 export GETX_API_KEY="..."        # GetXAPI
+export XQUIK_API_KEY="..."       # Xquik
 export TWITTERAPI_IO_KEY="..."   # twitterapi.io
 export X_BEARER_TOKEN="..."      # Official X API v2
-export TWITTER_API_BACKEND="auto"  # auto|getxapi|twitterapiio|official
+export TWITTER_API_BACKEND="auto"  # auto|getxapi|xquik|twitterapiio|official
 # Web Search
 export TAVILY_API_KEY="tvly-xxx"   # Tavily Search API
 export BRAVE_API_KEYS="k1,k2,k3"   # Brave Search API keys (comma-separated for rotation)
@@ -174,3 +175,5 @@ pip install weasyprint
 ## 📄 License
 
 MIT License — see [LICENSE](LICENSE) for details.
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.

--- a/README_CN.md
+++ b/README_CN.md
@@ -112,11 +112,12 @@ cp config/defaults/topics.json workspace/config/tech-news-digest-topics.json
 
 ## 🔧 环境变量
 
-# Twitter/X 后端（自动优先级：getxapi > twitterapiio > official）
+# Twitter/X 后端（自动优先级：getxapi > xquik > twitterapiio > official）
 export GETX_API_KEY="..."        # GetXAPI
+export XQUIK_API_KEY="..."       # Xquik
 export TWITTERAPI_IO_KEY="..."   # twitterapi.io
 export X_BEARER_TOKEN="..."      # Twitter/X 官方 API v2
-export TWITTER_API_BACKEND="auto"  # auto|getxapi|twitterapiio|official
+export TWITTER_API_BACKEND="auto"  # auto|getxapi|xquik|twitterapiio|official
 # 网页搜索
 export TAVILY_API_KEY="tvly-xxx"   # Tavily Search API
 export BRAVE_API_KEYS="k1,k2,k3"   # Brave Search API 密钥（逗号分隔用于轮换）

--- a/scripts/fetch-twitter.py
+++ b/scripts/fetch-twitter.py
@@ -3,17 +3,18 @@
 Fetch Twitter/X posts from KOL accounts using X API.
 
 Reads sources.json, filters Twitter sources, fetches recent posts using
-either the official X API v2 or twitterapi.io, and outputs structured JSON.
+official X API v2, GetXAPI, Xquik, or twitterapi.io, and outputs structured JSON.
 
 Usage:
     python3 fetch-twitter.py [--config CONFIG_DIR] [--hours 48] [--output FILE] [--verbose]
-    python3 fetch-twitter.py --backend twitterapiio  # force twitterapi.io backend
+    python3 fetch-twitter.py --backend xquik  # force Xquik backend
 
 Environment:
-    TWITTER_API_BACKEND - Backend selection: "auto" (default), "getxapi", "twitterapiio", or "official"
-                        Auto priority: getxapi ($0.001/call) > twitterapi.io (~$5/mo) > official X API
-    GETX_API_KEY        - GetXAPI API key (preferred backend, $0.001 per call)
-    TWITTERAPI_IO_KEY   - twitterapi.io API key (alternative backend, ~$5/month)
+    TWITTER_API_BACKEND - Backend selection: "auto" (default), "getxapi", "xquik", "twitterapiio", or "official"
+                        Auto priority: getxapi > xquik > twitterapi.io > official X API
+    GETX_API_KEY        - GetXAPI API key (preferred backend)
+    XQUIK_API_KEY       - Xquik API key (alternative backend)
+    TWITTERAPI_IO_KEY   - twitterapi.io API key (alternative backend)
     X_BEARER_TOKEN      - Twitter/X official API v2 bearer token (fallback)
 """
 
@@ -31,7 +32,7 @@ from datetime import datetime, timedelta, timezone
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 from pathlib import Path
 from typing import Dict, List, Any, Optional
 
@@ -50,6 +51,8 @@ USER_LOOKUP_ENDPOINT = f"{OFFICIAL_API_BASE}/users/by"
 # twitterapi.io endpoints
 TWITTERAPIIO_BASE = "https://api.twitterapi.io"
 GETXAPI_BASE = "https://api.getxapi.com"
+XQUIK_API_BASE = "https://xquik.com/api/v1"
+XQUIK_API_CONTRACT = "2026-04-29"
 
 
 def setup_logging(verbose: bool) -> logging.Logger:
@@ -493,6 +496,225 @@ class TwitterApiIoBackend(TwitterBackend):
         return results
 
 
+class XquikBackend(TwitterBackend):
+    """Xquik backend for user timeline reads."""
+
+    def __init__(self, api_key: str):
+        if not api_key or len(api_key) < 10:
+            raise ValueError("Invalid XQUIK_API_KEY format - expected at least 10 characters")
+        self.api_key = api_key
+        self._limiter = RateLimiter(qps=5)
+        self.logger = logging.getLogger("fetch-twitter")
+
+    @staticmethod
+    def _parse_date(date_str: str) -> Optional[datetime]:
+        """Parse Xquik date strings from the normalized v1 API contract."""
+        if not date_str:
+            return None
+        try:
+            normalized = date_str[:-1] + "+00:00" if date_str.endswith("Z") else date_str
+            dt = datetime.fromisoformat(normalized)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except (ValueError, TypeError):
+            logging.debug(f"Failed to parse Xquik date: {date_str}")
+            return None
+
+    @staticmethod
+    def _get_first(data: Dict[str, Any], *keys: str, default: Any = None) -> Any:
+        for key in keys:
+            if key in data and data[key] is not None:
+                return data[key]
+        return default
+
+    @classmethod
+    def _get_count(cls, data: Dict[str, Any], *keys: str) -> int:
+        value = cls._get_first(data, *keys, default=0)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _extract_tweets(raw: Dict[str, Any]) -> List[Dict[str, Any]]:
+        data = raw.get("data", raw)
+        if isinstance(data, list):
+            return [item for item in data if isinstance(item, dict)]
+        if not isinstance(data, dict):
+            return []
+        candidates = (
+            data.get("tweets"),
+            data.get("items"),
+            data.get("results"),
+            raw.get("tweets"),
+            raw.get("items"),
+            raw.get("results"),
+        )
+        for candidate in candidates:
+            if isinstance(candidate, list):
+                return [item for item in candidate if isinstance(item, dict)]
+        return []
+
+    @staticmethod
+    def _extract_next_cursor(raw: Dict[str, Any]) -> Optional[str]:
+        data = raw.get("data", raw)
+        containers = [raw]
+        if isinstance(data, dict):
+            containers.append(data)
+            pagination = data.get("pagination")
+            if isinstance(pagination, dict):
+                containers.append(pagination)
+        for container in containers:
+            for key in ("next_cursor", "nextCursor", "cursor"):
+                value = container.get(key)
+                if value:
+                    return str(value)
+        return None
+
+    @staticmethod
+    def _has_next_page(raw: Dict[str, Any]) -> bool:
+        data = raw.get("data", raw)
+        containers = [raw]
+        if isinstance(data, dict):
+            containers.append(data)
+            pagination = data.get("pagination")
+            if isinstance(pagination, dict):
+                containers.append(pagination)
+        return any(bool(container.get(key)) for container in containers for key in ("has_next_page", "has_more", "hasMore"))
+
+    def _parse_tweets_page(self, tweets: list, handle: str, topics: list, cutoff: datetime) -> list:
+        articles = []
+        for tweet in tweets:
+            tweet_id = self._get_first(tweet, "id", "tweet_id", "tweetId")
+            text = self._get_first(tweet, "text", "full_text", "fullText")
+            created_at_raw = self._get_first(tweet, "createdAt", "created_at")
+            if not tweet_id or not text or not created_at_raw:
+                continue
+            if tweet.get("retweeted_tweet") or tweet.get("retweetedTweet"):
+                continue
+            if tweet.get("isReply") or tweet.get("is_reply") or tweet.get("inReplyToId"):
+                continue
+            if text.startswith("RT @"):
+                continue
+
+            created_at = self._parse_date(created_at_raw)
+            if not created_at or created_at < cutoff:
+                continue
+
+            link = self._get_first(tweet, "url", "link") or f"https://x.com/{handle}/status/{tweet_id}"
+
+            articles.append({
+                "title": clean_tweet_text(text),
+                "link": link,
+                "date": created_at.isoformat(),
+                "topics": topics[:],
+                "metrics": {
+                    "like_count": self._get_count(tweet, "likeCount", "like_count", "likes"),
+                    "retweet_count": self._get_count(tweet, "retweetCount", "retweet_count", "retweets"),
+                    "reply_count": self._get_count(tweet, "replyCount", "reply_count", "replies"),
+                    "quote_count": self._get_count(tweet, "quoteCount", "quote_count", "quotes"),
+                    "impression_count": self._get_count(tweet, "viewCount", "view_count", "impression_count", "impressions"),
+                },
+                "tweet_id": str(tweet_id),
+            })
+        return articles
+
+    def _build_url(self, handle: str, cursor: Optional[str] = None) -> str:
+        params = {
+            "includeReplies": "false",
+        }
+        if cursor:
+            params["cursor"] = cursor
+        return f"{XQUIK_API_BASE}/x/users/{quote(handle, safe='')}/tweets?{urlencode(params)}"
+
+    def _fetch_page(self, handle: str, headers: Dict[str, str], cursor: Optional[str] = None) -> Dict[str, Any]:
+        self._limiter.wait()
+        req = Request(self._build_url(handle, cursor), headers=headers)
+        with urlopen(req, timeout=TIMEOUT) as resp:
+            return json.loads(resp.read().decode())
+
+    def _fetch_user_tweets(self, source: Dict[str, Any], cutoff: datetime) -> Dict[str, Any]:
+        handle = source["handle"].lstrip('@')
+        topics = source["topics"]
+
+        for attempt in range(RETRY_COUNT + 1):
+            try:
+                headers = {
+                    "x-api-key": self.api_key,
+                    "xquik-api-contract": XQUIK_API_CONTRACT,
+                    "Accept": "application/json",
+                    "User-Agent": "TechDigest/2.0",
+                }
+
+                raw = self._fetch_page(handle, headers)
+                if raw.get("error"):
+                    return self._make_error(source, str(raw["error"])[:100], attempt)
+
+                articles = self._parse_tweets_page(
+                    self._extract_tweets(raw), handle, topics, cutoff
+                )
+
+                has_next = self._has_next_page(raw)
+                next_cursor = self._extract_next_cursor(raw)
+                if has_next and next_cursor and articles:
+                    oldest = min(datetime.fromisoformat(a["date"]) for a in articles)
+                    if oldest >= cutoff:
+                        raw2 = self._fetch_page(handle, headers, next_cursor)
+                        if raw2.get("error"):
+                            raise ValueError(str(raw2["error"])[:100])
+                        articles.extend(self._parse_tweets_page(
+                            self._extract_tweets(raw2), handle, topics, cutoff
+                        ))
+                        has_next = self._has_next_page(raw2)
+
+                if has_next and articles:
+                    oldest = min(datetime.fromisoformat(a["date"]) for a in articles)
+                    if oldest >= cutoff:
+                        logging.warning(f"@{handle}: results may be truncated ({len(articles)} tweets, more available)")
+
+                return self._make_result(source, articles, attempt)
+
+            except HTTPError as e:
+                if e.code == 429:
+                    error_msg = "Rate limit exceeded"
+                    logging.warning(f"Rate limit hit for @{handle}, attempt {attempt + 1}")
+                    if attempt < RETRY_COUNT:
+                        time.sleep(5)
+                        continue
+                else:
+                    error_msg = f"HTTP {e.code}: {e.reason}"
+
+            except Exception as e:
+                error_msg = str(e)[:100]
+                logging.debug(f"Attempt {attempt + 1} failed for @{handle}: {error_msg}")
+
+            if attempt < RETRY_COUNT:
+                time.sleep(RETRY_DELAY * (2 ** attempt))
+                continue
+
+            return self._make_error(source, error_msg, attempt)
+
+    def fetch_all(self, sources: List[Dict[str, Any]], cutoff: datetime) -> List[Dict[str, Any]]:
+        results: List[Dict[str, Any]] = []
+        total = len(sources)
+        done = 0
+        with ThreadPoolExecutor(max_workers=5) as pool:
+            futures = {pool.submit(self._fetch_user_tweets, source, cutoff): source
+                       for source in sources}
+            for future in as_completed(futures):
+                result = future.result()
+                results.append(result)
+                done += 1
+                if result["status"] == "ok":
+                    logging.info(f"[{done}/{total}] ✅ @{result['handle']}: {result['count']} tweets"
+                                 + (f" (top: {result['articles'][0]['metrics']['like_count']}❤️)" if result['articles'] else ""))
+                else:
+                    logging.warning(f"[{done}/{total}] ❌ @{result['handle']}: {result['error']}")
+
+        return results
+
+
 class GetXApiBackend(TwitterBackend):
     """GetXAPI backend."""
 
@@ -687,6 +909,14 @@ def select_backend(backend_name: str, no_cache: bool = False) -> Optional[Twitte
         logging.info("Using twitterapi.io backend")
         return TwitterApiIoBackend(key)
 
+    if backend_name == "xquik":
+        key = os.getenv("XQUIK_API_KEY")
+        if not key:
+            logging.error("XQUIK_API_KEY not set (required for xquik backend)")
+            return None
+        logging.info("Using Xquik backend")
+        return XquikBackend(key)
+
     if backend_name == "official":
         token = os.getenv("X_BEARER_TOKEN")
         if not token:
@@ -695,12 +925,16 @@ def select_backend(backend_name: str, no_cache: bool = False) -> Optional[Twitte
         logging.info("Using official X API v2 backend")
         return OfficialBackend(token, no_cache=no_cache)
 
-    # auto: try getxapi first, then twitterapiio, then official
+    # auto: try getxapi first, then xquik, then twitterapiio, then official
     if backend_name == "auto":
         getx_key = os.getenv("GETX_API_KEY")
         if getx_key:
             logging.info("Auto-selected GetXAPI backend (GETX_API_KEY set)")
             return GetXApiBackend(getx_key)
+        xquik_key = os.getenv("XQUIK_API_KEY")
+        if xquik_key:
+            logging.info("Auto-selected Xquik backend (XQUIK_API_KEY set)")
+            return XquikBackend(xquik_key)
         key = os.getenv("TWITTERAPI_IO_KEY")
         if key:
             logging.info("Auto-selected twitterapi.io backend (TWITTERAPI_IO_KEY set)")
@@ -709,7 +943,7 @@ def select_backend(backend_name: str, no_cache: bool = False) -> Optional[Twitte
         if token:
             logging.info("Auto-selected official X API v2 backend (X_BEARER_TOKEN set)")
             return OfficialBackend(token, no_cache=no_cache)
-        logging.warning("No Twitter API credentials found (checked GETX_API_KEY, TWITTERAPI_IO_KEY, X_BEARER_TOKEN)")
+        logging.warning("No Twitter API credentials found (checked GETX_API_KEY, XQUIK_API_KEY, TWITTERAPI_IO_KEY, X_BEARER_TOKEN)")
         return None
 
     logging.error(f"Unknown backend: {backend_name}")
@@ -754,14 +988,14 @@ def main():
     """Main Twitter fetching function."""
     parser = argparse.ArgumentParser(
         description="Fetch recent tweets from Twitter/X KOL accounts. "
-                   "Supports official X API v2, GetXAPI, and twitterapi.io backends.",
+                   "Supports official X API v2, GetXAPI, Xquik, and twitterapi.io backends.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
     export X_BEARER_TOKEN="your_token_here"
     python3 fetch-twitter.py
     python3 fetch-twitter.py --defaults config/defaults --config workspace/config --hours 24 -o results.json
-    python3 fetch-twitter.py --backend twitterapiio  # use twitterapi.io
+    python3 fetch-twitter.py --backend xquik  # use Xquik
     python3 fetch-twitter.py --config workspace/config --verbose  # backward compatibility
         """
     )
@@ -812,10 +1046,10 @@ Examples:
 
     parser.add_argument(
         "--backend",
-        choices=["official", "twitterapiio", "getxapi", "auto"],
+        choices=["official", "twitterapiio", "getxapi", "xquik", "auto"],
         default=None,
         help="Twitter API backend (overrides TWITTER_API_BACKEND env var). "
-             "auto = getxapi if GETX_API_KEY set, else twitterapiio if TWITTERAPI_IO_KEY set, else official if X_BEARER_TOKEN set"
+             "auto = getxapi if GETX_API_KEY set, else xquik if XQUIK_API_KEY set, else twitterapiio if TWITTERAPI_IO_KEY set, else official if X_BEARER_TOKEN set"
     )
 
     args = parser.parse_args()

--- a/scripts/run-pipeline.py
+++ b/scripts/run-pipeline.py
@@ -129,7 +129,7 @@ def main() -> int:
     parser.add_argument("--archive-dir", type=Path, default=None, help="Archive dir for dedup penalty")
     parser.add_argument("--output", "-o", type=Path, default=Path("/tmp/td-merged.json"), help="Final merged output")
     parser.add_argument("--step-timeout", type=int, default=DEFAULT_TIMEOUT, help="Per-step timeout (seconds)")
-    parser.add_argument("--twitter-backend", choices=["official", "twitterapiio", "getxapi", "auto"], default=None, help="Twitter API backend to use")
+    parser.add_argument("--twitter-backend", choices=["official", "twitterapiio", "getxapi", "xquik", "auto"], default=None, help="Twitter API backend to use")
     parser.add_argument("--verbose", "-v", action="store_true")
     parser.add_argument("--force", action="store_true", help="Force re-fetch ignoring caches")
     parser.add_argument("--enrich", action="store_true", help="Enable full-text enrichment for top articles")

--- a/scripts/test-pipeline.sh
+++ b/scripts/test-pipeline.sh
@@ -8,7 +8,7 @@
 #   ./test-pipeline.sh --ids sama-twitter,openai-rss  # specific source IDs
 #   ./test-pipeline.sh --hours 12               # custom time window
 #   ./test-pipeline.sh --keep                   # keep output dir after test
-#   ./test-pipeline.sh --twitter-backend twitterapiio  # force twitter backend
+#   ./test-pipeline.sh --twitter-backend xquik  # force twitter backend
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -68,10 +68,12 @@ OPTIONS:
 
   --twitter-backend NAME
                     Force a specific Twitter API backend
-                    Values: official, twitterapiio, auto
+                    Values: official, twitterapiio, getxapi, xquik, auto
                     official     = X API v2 (needs X_BEARER_TOKEN)
                     twitterapiio = twitterapi.io (needs TWITTERAPI_IO_KEY)
-                    auto         = try twitterapiio first, fallback to official
+                    getxapi      = GetXAPI (needs GETX_API_KEY)
+                    xquik        = Xquik (needs XQUIK_API_KEY)
+                    auto         = try getxapi, xquik, twitterapiio, then official
 
   --config DIR      User config overlay directory (optional)
                     Example: --config workspace/config
@@ -84,7 +86,7 @@ OPTIONS:
 
 EXAMPLES:
   ./test-pipeline.sh                                    # full pipeline, all sources
-  ./test-pipeline.sh --only twitter --twitter-backend twitterapiio  # twitter only via twitterapi.io
+  ./test-pipeline.sh --only twitter --twitter-backend xquik  # twitter only via Xquik
   ./test-pipeline.sh --topics crypto --hours 48 --keep  # crypto sources, 48h window
   ./test-pipeline.sh --skip web,reddit -v               # skip web+reddit, verbose
   ./test-pipeline.sh --ids sama-twitter,karpathy-twitter --only twitter
@@ -92,7 +94,9 @@ EXAMPLES:
 ENVIRONMENT:
   X_BEARER_TOKEN      Official X API v2 bearer token (for --backend official)
   TWITTERAPI_IO_KEY   twitterapi.io API key (for --backend twitterapiio)
-  TWITTER_API_BACKEND Default twitter backend if --backend not given (official|twitterapiio|auto)
+  GETX_API_KEY        GetXAPI key (for --backend getxapi)
+  XQUIK_API_KEY       Xquik API key (for --backend xquik)
+  TWITTER_API_BACKEND Default twitter backend if --backend not given (official|twitterapiio|getxapi|xquik|auto)
   BRAVE_API_KEY       Brave Search API key (for web fetch)
   GITHUB_TOKEN        GitHub token (optional, increases GitHub API rate limits)
 HELP
@@ -223,11 +227,11 @@ if should_run "twitter"; then
     TWITTER_ARGS=("--defaults" "$DEFAULTS" "--hours" "$HOURS" "--output" "$OUTDIR/twitter.json" "--force" "${EXTRA_ARGS[@]}")
     [ -n "$TWITTER_BACKEND" ] && TWITTER_ARGS+=("--backend" "$TWITTER_BACKEND")
 
-    if [ -n "$X_BEARER_TOKEN" ] || [ -n "$TWITTERAPI_IO_KEY" ]; then
+    if [ -n "$X_BEARER_TOKEN" ] || [ -n "$TWITTERAPI_IO_KEY" ] || [ -n "$GETX_API_KEY" ] || [ -n "$XQUIK_API_KEY" ]; then
         run_step "fetch-twitter" python3 "$SCRIPT_DIR/fetch-twitter.py" "${TWITTER_ARGS[@]}"
         validate_json "$OUTDIR/twitter.json" "twitter"
     else
-        echo "⏭  fetch-twitter (no X_BEARER_TOKEN or TWITTERAPI_IO_KEY)"
+        echo "⏭  fetch-twitter (no X_BEARER_TOKEN, TWITTERAPI_IO_KEY, GETX_API_KEY, or XQUIK_API_KEY)"
         SKIPPED=$((SKIPPED + 1))
     fi
 else

--- a/tests/test_fetch_twitter.py
+++ b/tests/test_fetch_twitter.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Regression tests for fetch-twitter.py."""
+
+import importlib.util
+import json
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+spec = importlib.util.spec_from_file_location("fetch_twitter", SCRIPTS_DIR / "fetch-twitter.py")
+fetch_twitter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(fetch_twitter)
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode()
+
+
+class TestXquikBackend(unittest.TestCase):
+    def test_select_backend_requires_xquik_api_key(self):
+        with patch.dict(fetch_twitter.os.environ, {}, clear=True):
+            backend = fetch_twitter.select_backend("xquik")
+
+        self.assertIsNone(backend)
+
+    def test_select_backend_uses_xquik_api_key(self):
+        with patch.dict(fetch_twitter.os.environ, {"XQUIK_API_KEY": "xquik_test_key"}, clear=True):
+            backend = fetch_twitter.select_backend("xquik")
+
+        self.assertIsInstance(backend, fetch_twitter.XquikBackend)
+
+    def test_xquik_backend_maps_tweets_to_articles(self):
+        backend = fetch_twitter.XquikBackend("xquik_test_key")
+        source = {
+            "id": "openai-twitter",
+            "name": "OpenAI",
+            "handle": "@openai",
+            "priority": True,
+            "topics": ["llm"],
+        }
+        created_at = datetime.now(timezone.utc).isoformat()
+        payload = {
+            "tweets": [
+                {
+                    "id": "123",
+                    "text": "Launch notes",
+                    "createdAt": created_at,
+                    "url": "https://x.com/openai/status/123",
+                    "likeCount": 7,
+                    "retweetCount": 2,
+                    "replyCount": 1,
+                    "quoteCount": 0,
+                    "viewCount": 100,
+                }
+            ],
+            "has_next_page": False,
+            "next_cursor": "",
+        }
+        captured_requests = []
+
+        def fake_urlopen(request, timeout):
+            captured_requests.append(request)
+            return FakeResponse(payload)
+
+        with patch.object(fetch_twitter, "urlopen", side_effect=fake_urlopen):
+            result = backend._fetch_user_tweets(source, datetime.now(timezone.utc) - timedelta(hours=1))
+
+        headers = {key.lower(): value for key, value in captured_requests[0].header_items()}
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["articles"][0]["tweet_id"], "123")
+        self.assertEqual(result["articles"][0]["metrics"]["like_count"], 7)
+        self.assertIn("/x/users/openai/tweets", captured_requests[0].full_url)
+        self.assertEqual(headers["x-api-key"], "xquik_test_key")
+        self.assertEqual(headers["xquik-api-contract"], fetch_twitter.XQUIK_API_CONTRACT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 spec = importlib.util.spec_from_file_location("run_pipeline", SCRIPTS_DIR / "run-pipeline.py")
@@ -14,6 +15,38 @@ spec.loader.exec_module(run_pipeline)
 
 
 class TestRunPipeline(unittest.TestCase):
+    def test_skip_trending_prevents_the_fetch_step(self):
+        calls = []
+
+        def fake_run_step(name, *args, **kwargs):
+            calls.append(name)
+            return {
+                "name": name,
+                "status": "ok",
+                "elapsed_s": 0,
+                "count": 0,
+                "stderr_tail": [],
+            }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "out.json"
+            old_argv = sys.argv
+            sys.argv = [
+                "run-pipeline.py",
+                "--skip",
+                "rss,twitter,github,trending,reddit,web",
+                "--output",
+                str(output_path),
+            ]
+            try:
+                with patch.object(run_pipeline, "run_step", side_effect=fake_run_step):
+                    rc = run_pipeline.main()
+            finally:
+                sys.argv = old_argv
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls, ["Merge", "Health"])
+
     def test_returns_nonzero_when_fetch_step_fails(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "out.json"
@@ -44,6 +77,26 @@ class TestRunPipeline(unittest.TestCase):
                 "run-pipeline.py",
                 "--twitter-backend",
                 "getxapi",
+                "--skip",
+                "rss,twitter,github,trending,reddit,web",
+                "--output",
+                str(output_path),
+            ]
+            try:
+                rc = run_pipeline.main()
+            finally:
+                sys.argv = old_argv
+
+            self.assertEqual(rc, 0)
+
+    def test_accepts_xquik_twitter_backend(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "out.json"
+            old_argv = sys.argv
+            sys.argv = [
+                "run-pipeline.py",
+                "--twitter-backend",
+                "xquik",
                 "--skip",
                 "rss,twitter,github,trending,reddit,web",
                 "--output",


### PR DESCRIPTION
## Summary

- Add an optional Xquik backend for Twitter/X KOL monitoring through `XQUIK_API_KEY`.
- Wire the backend through the fetcher, pipeline CLI, smoke-test wrapper, English and Chinese docs, skill metadata, changelog, and regression tests.
- Preserve the current upstream PDF and prompt changes by rebuilding on the latest `main`.

## Repository fix

`--skip trending` did not skip the `GitHub Trending` step because filtering compared the documented key with the display label. Even the existing skip-all test still made that network call. The pipeline now maps the display label to the documented `trending` key, and a regression test proves skip-all runs only Merge and Health.

## Xquik behavior

- Authenticate with the `x-api-key` header.
- Read `GET /api/v1/x/users/{id}/tweets`.
- Normalize tweets, metrics, dates, pagination, retweet filtering, and reply filtering into the existing article model.
- Select Xquik explicitly or automatically when `XQUIK_API_KEY` is configured.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.

## Validation

- `python3 -m pytest -q` - 57 passed
- `python3 -m py_compile scripts/*.py tests/*.py`
- `python3 scripts/validate-config.py --defaults config/defaults`
- `bash -n scripts/test-pipeline.sh`
- `git diff --check`

The branch contains exactly 1 current-upstream, GitHub-verified SSH-signed commit.